### PR TITLE
fix(layout): removed leading space from prequery()

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -37,7 +37,7 @@
 /// - fallback (content): the fallback content to display when in fallback mode
 /// -> content
 #let prequery(meta, lbl, body, fallback: none) = {
-  [#metadata(meta) #lbl]
+  [#metadata(meta)#lbl]
   context {
     if not _fallback.get() {
       if type(body) != function {


### PR DESCRIPTION
I tried inserting value like `(#prequery(...))` and found out that there is an extra space that causes this behavior.